### PR TITLE
Fixing plug list.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,7 @@ apps:
             - network
             - removable-media
             - hardware-observe
+            - mount-observe
             - raw-usb
             - udisks2
 
@@ -87,7 +88,7 @@ parts:
 
         override-pull: |
             craftctl default
-            _pkgversion="snap3"
+            _pkgversion="snap4"
             _version="$(git describe --tags | cut -d_ -f2 | grep -o '^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+\(-[A-z0-9]\+\)\?')"
 
             # Set Snap package version


### PR DESCRIPTION
Even though Snapcraft documentation states that 'gnome' extension would include 'mount-observe' plug, that didn't happen in reality - see:

https://github.com/ivocavalcante/PrusaSlicer-snap/issues/12

Hence, I'm including it here again.